### PR TITLE
fix: update documentation to use correct package naming convention fo…

### DIFF
--- a/docs/analytics.rst
+++ b/docs/analytics.rst
@@ -39,8 +39,8 @@ To use the `ApiKeyAnalyticsMiddleware`, follow these setup instructions:
        INSTALLED_APPS = (
            ...
            "rest_framework",
-           "drf-simple-apikey",
-           "drf-simple-apikey.analytics",  # Ensure this app is added
+           "drf_simple_apikey",
+           "drf_simple_apikey.analytics",  # Ensure this app is added
        )
 
 2. Add the `ApiKeyAnalyticsMiddleware` to the `MIDDLEWARE` settings in your Django configuration.
@@ -50,7 +50,7 @@ To use the `ApiKeyAnalyticsMiddleware`, follow these setup instructions:
        MIDDLEWARE = [
            ...
            'django.middleware.security.SecurityMiddleware',
-           'drf-simple-apikey.analytics.middleware.ApiKeyAnalyticsMiddleware',  # Add the middleware here
+           'drf_simple_apikey.analytics.middleware.ApiKeyAnalyticsMiddleware',  # Add the middleware here
            ...
        ]
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,7 +58,7 @@ file:
    INSTALLED_APPS = [
      # ...
      "rest_framework",
-     "drf-simple-apikey",
+     "drf_simple_apikey",
    ]
 
 3- Add the ``FERNET_KEY`` setting in your ``DRF_API_KEY``
@@ -88,7 +88,7 @@ permission class.
 
    from rest_framework import viewsets
 
-   from drf-simple-apikey.backends import APIKeyAuthentication
+   from drf_simple_apikey.backends import APIKeyAuthentication
    from rest_framework.response import Response
 
    class FruitViewSets(viewsets.ViewSet):

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -31,7 +31,7 @@ You can then call use this class in your view 👇
 
 .. code:: python
 
-   from drf-simple-apikey.permissions import IsActiveEntity
+   from drf_simple_apikey.permissions import IsActiveEntity
 
    class YourViewSet(viewsets.ViewSet):
        ...

--- a/docs/rotation.rst
+++ b/docs/rotation.rst
@@ -23,15 +23,15 @@ Activation
 
 Before activating a rotation, ensure to set the rotating Fernet key ``ROTATION_FERNET_SECRET`` in the settings of the package.
 
-You will need to add the rotation app ``drf-simple-apikey.rotation`` in the ``INSTALLED_APPS`` Django setting of your project.
+You will need to add the rotation app ``drf_simple_apikey.rotation`` in the ``INSTALLED_APPS`` Django setting of your project.
 
    .. code-block:: python
 
        INSTALLED_APPS=(
             ...
             "rest_framework",
-            "drf-simple-apikey",
-            "drf-simple-apikey.rotation", # added app
+            "drf_simple_apikey",
+            "drf_simple_apikey.rotation", # added app
         )
 
 And you will need to run the migrate command:


### PR DESCRIPTION
This commit updates the documentation to ensure the correct package naming convention for drf_simple_apikey is used. The previous documentation was misleading because it used drf-simple-apikey instead of drf_simple_apikey. It is a simple mistake but caused me some trouble ahhaha. This change addresses the issue by correcting the package docs.